### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -1,4 +1,6 @@
 name: Unity Package Runtime Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Mateo-Jimenez76/Unity-Health-Script/security/code-scanning/2](https://github.com/Mateo-Jimenez76/Unity-Health-Script/security/code-scanning/2)

To fix the issue, we should add a `permissions` block to the workflow file, either at the root level or for the individual job(s). The minimal starting point recommended by CodeQL is `contents: read`, which allows reading repository contents while prohibiting any write or extra access. This aligns with the least privilege principle. We should add the following near the top of the file, preferably just below the workflow `name:` field or above `jobs:`. Editing `.github/workflows/unity-tests.yml` by inserting a block:

```yaml
permissions:
  contents: read
```

No other dependencies or code changes are required, and no changes are needed to other jobs or steps unless finer-grained permissions are required for some actions (which does not appear to be the case here). The change is fully isolated and safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
