### PR TITLE
chore: Update unity-tests workflow to trigger on pull requests only

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -3,9 +3,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
         - main


### PR DESCRIPTION
Removed push trigger from unity-tests workflow as branch protection prevents direct pushing into main. Action is ran on pull request so no need to run on the merge from that pull request.