### PR TITLE
chore: Set changelog PR to always be a draft

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -39,3 +39,5 @@ jobs:
           body: 'Changelog update created by TriPSs/conventional-changelog-action@v5'
 
           base: main
+
+          draft: always-true


### PR DESCRIPTION
Attempting to fix unity tests workflow not triggering when a pull request is made.